### PR TITLE
Refactor(portfolio): Replace Next.js Image with standard img tag

### DIFF
--- a/src/components/sections/portfolio.tsx
+++ b/src/components/sections/portfolio.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from 'next/image';
 import { Card, CardContent } from '@/components/ui/card';
 import { motion } from 'framer-motion';
 
@@ -162,11 +161,9 @@ const PortfolioImage = ({ src, w, h, alt, featured = false }: { src?: string, w:
   >
     <Card className="overflow-hidden shadow-sm hover:shadow-md transition-shadow duration-300 border-0 rounded-md h-full">
       <CardContent className="p-0 h-full">
-        <Image
+        <img
           src={src || `https://placehold.co/${w}x${h}.png`}
           alt={alt || "Foto de portfolio de Camila Tessio"}
-          width={w}
-          height={h}
           className="w-full h-full object-cover"
           loading="lazy"
           data-ai-hint="fashion model portrait"


### PR DESCRIPTION
- Removes the `next/image` import from `portfolio.tsx`.
- Replaces the `<Image>` component with a standard `<img>` tag in the `PortfolioImage` component.
- Keeps the `src`, `alt`, `className`, `loading`, and `data-ai-hint` attributes.
- Removes the `width` and `height` props as they are no longer necessary for the `<img>` tag in this context.

This change is made to avoid using the Vercel image optimization service.